### PR TITLE
Initialize coolingIdealTemp and sleepIdealTemp to 0 instead of ''

### DIFF
--- a/SenseME.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/SenseME.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -273,8 +273,8 @@ class Plugin(indigo.PluginBase):
                 'beep'            : '',
                 'indicators'      : '',
                 'direction'       : '',
-                'coolingIdealTemp': '',
-                'sleepIdealTemp'  : '',
+                'coolingIdealTemp': '0',
+                'sleepIdealTemp'  : '0',
                 'status_string'   : '',
                 'sleepMode'       : '',
                 'dev'             : dev


### PR DESCRIPTION
This appears to allow the configuration UI to validate when saving a
device that was originally created with 0.6.1 (and is missing those fields)