### PR TITLE
Revert "Initialize coolingIdealTemp and sleepIdealTemp to 0 instead of ''"

### DIFF
--- a/SenseME.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/SenseME.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -273,8 +273,8 @@ class Plugin(indigo.PluginBase):
                 'beep'            : '',
                 'indicators'      : '',
                 'direction'       : '',
-                'coolingIdealTemp': '0',
-                'sleepIdealTemp'  : '0',
+                'coolingIdealTemp': '',
+                'sleepIdealTemp'  : '',
                 'status_string'   : '',
                 'sleepMode'       : '',
                 'dev'             : dev


### PR DESCRIPTION
Reverts bpennypacker/SenseME-Indigo-Plugin#11

I actually just realized that I shouldn't have merged this so I have reverted it. I need to research what this is intended to fix, as this fix is going to cause unexpected behavior.

The dict that's modified in this PR is just a temporary state that should be completely empty when Indigo initially creates the device. Because the device was just created neither the plugin nor Indigo itself has any idea what the current state of the fan is, so all those values are considered "undefined".  Immediately after this dict is initialized a call is made to `getFanStatus()` which causes the fan to respond with a series of messages back to the plugin that lists the current state of every fan parameter. Those messages are received by the plugin via the `processFanMessage()` function, which updates the dict with the actual current state of each property that is tracked in the dict. `processFanMessage()` also calls `dev.updateStateOnServer()` for each property to ensure Indigo itself knows the current state, and it sets the parameter `triggerEvents` to False if the old value in the dict was set to `''`. This ensures Indigo knows the current state but doesn't actually trigger the associated action. If `triggerEvents` is set to true then Indigo would trigger the action.

So by setting `coolingIdealTemp` and `sleepIdealTemp` to '0' rather than '' this is likely causing those actions in Indigo to trigger any time the plugin is restarted. If these really do need to be set to '0' initially then the respective `triggerEvents` check in the appropriate sections of `processFanMessage()` would also need to be updated. Also the related section where the device state is reinitialized (search for `msgtype == MSG_REINIT`) would also need to be updated to set these to '0' instead of ''.